### PR TITLE
Disable travis ci mac osx inspection of the PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,18 @@ matrix:
 #      os: linux
 #      dist: bionic  # Ubuntu 18.04
 #      python: 3.7
-    - name: "OSX xcode10.2 - Python 3"
-      os: osx
-      osx_image: xcode10.2
-      language: generic
-      addons:
-        homebrew:
-          # update: true
-          packages: python3
-      before_install:
-        - pip3 install virtualenv
-        - virtualenv -p python3 ~/venv
-        - source ~/venv/bin/activate
+#    - name: "OSX xcode10.2 - Python 3"
+#      os: osx
+#      osx_image: xcode10.2
+#      language: generic
+#      addons:
+#        homebrew:
+#          # update: true
+#          packages: python3
+#      before_install:
+#        - pip3 install virtualenv
+#        - virtualenv -p python3 ~/venv
+#        - source ~/venv/bin/activate
 
 #cache: pip
 


### PR DESCRIPTION
Mac PR evaluation will be covered by GitHub Action as it is way faster there than via Travis