### PR TITLE
Switch around TTDistributedDataParallel inheritance

### DIFF
--- a/aitoolbox/torchtrain/parallel.py
+++ b/aitoolbox/torchtrain/parallel.py
@@ -63,7 +63,7 @@ class TTDataParallel(nn.DataParallel, TTParallelBase):
         TTParallelBase.__init__(self, module, default_model_methods)
 
 
-class TTDistributedDataParallel(DistributedDataParallel, TTParallelBase):
+class TTDistributedDataParallel(TTParallelBase, DistributedDataParallel):
     def __init__(self, module,
                  default_model_methods=('get_loss', 'get_loss_eval', 'get_predictions'), **kwargs):
         """torchtrain enabled DistributedDataParallel


### PR DESCRIPTION
Fix for the parent method resolution.

Otherwise, there is an error saying that the parameter (of the incorrectly resolutioned method) can't be found.